### PR TITLE
Support provided argument list instead of sys.argv to make it easier …

### DIFF
--- a/n2cw/cli.py
+++ b/n2cw/cli.py
@@ -26,7 +26,7 @@ class ParseKv(Action):
         setattr(namespace, self.dest, kv)
 
 
-def cli(args=sys.argv[:]):
+def cli(cliargs=sys.argv[:]):
     usage = "%(prog)s [options] namespace base_name -- command"
     ap = ArgumentParser(usage=usage, description=__doc__)
     ap.add_argument('--dimensions', metavar='key=value,key=value', default={},
@@ -45,8 +45,7 @@ def cli(args=sys.argv[:]):
                            dest='send_status', help="Don't send the check "
                            "status output")
 
-    args = ap.parse_args()
-
+    args = ap.parse_args(cliargs)
     result = 0
     try:
         output = check_output(args.command)


### PR DESCRIPTION
…to wrap the cli

Example of how I'd like to implement a wrapper:
```
    ap = argparse.ArgumentParser()
    ap.add_argument('--tag_dimension', default=[], action='append', help='EC2 instance tags to add')
    ap.add_argument('--dimensions', default="", help='fixed dimensions')
    (myargs,restargs) = ap.parse_known_args()
    new_dimensions=""
    for tag in myargs.tag_dimension:
        new_dimensions="," + tag + "=" + get_tag_value(tag)
    if len(myargs.dimensions) > 0:
        myargs.dimensions = myargs.dimensions + new_dimensions
    else:
        myargs.dimensions = new_dimensions[1:]
    if len(myargs.dimensions) > 0:
        restargs = ["--dimensions",myargs.dimensions] + restargs
    n2cw.cli.cli(restargs)
```